### PR TITLE
new command /status for sonarr/radarr system info

### DIFF
--- a/handler_start.go
+++ b/handler_start.go
@@ -24,6 +24,7 @@ func (e *Env) HandleStart(m *tb.Message) {
 		msg = append(msg, "")
 		msg = append(msg, "*Admin*")
 		msg = append(msg, "/users - list all bot users")
+		msg = append(msg, "/status - shows Sonarr/Radarr server status")
 	}
 
 	if exists && (user.IsMember() || user.IsAdmin()) {

--- a/handler_status.go
+++ b/handler_status.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	tb "gopkg.in/tucnak/telebot.v2"
+	"reflect"
+	"strings"
+)
+
+func (e *Env) HandleStatus(m *tb.Message) {
+
+	sonarrStatus, err := e.Sonarr.GetSystemStatus()
+	if err != nil {
+		SendError(e.Bot, m.Sender, "Failed to get Sonarr System Status.")
+	} else {
+		var msg []string
+		msg = append(msg, "*Sonarr Status:*")
+		s := reflect.ValueOf(&sonarrStatus).Elem()
+		typeOfT := s.Type()
+		for i := 0; i < s.NumField(); i++ {
+			f := s.Field(i)
+			msg = append(msg, fmt.Sprintf("%s = %v", typeOfT.Field(i).Name, f.Interface()))
+		}
+		Send(e.Bot, m.Sender, strings.Join(msg, "\n"))
+	}
+
+	radarrStatus, err := e.Radarr.GetSystemStatus()
+	if err != nil {
+		SendError(e.Bot, m.Sender, "Failed to get Radarr System Status.")
+	} else {
+		var msg []string
+		msg = append(msg, "*Radarr Status:*")
+		s := reflect.ValueOf(&radarrStatus).Elem()
+		typeOfT := s.Type()
+		for i := 0; i < s.NumField(); i++ {
+			f := s.Field(i)
+			msg = append(msg, fmt.Sprintf("%s = %v", typeOfT.Field(i).Name, f.Interface()))
+		}
+		Send(e.Bot, m.Sender, strings.Join(msg, "\n"))
+	}
+
+}

--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ func setupHandlers(r *Router, e *Env) {
 	r.HandleFunc("/addmovie", e.RequirePrivate(e.RequireAuth(UAMember, e.HandleAddMovie)))
 	r.HandleFunc("/addtv", e.RequirePrivate(e.RequireAuth(UAMember, e.HandleAddTVShow)))
 	r.HandleFunc("/users", e.RequirePrivate(e.RequireAuth(UAAdmin, e.HandleUsers)))
+	r.HandleFunc("/status", e.RequirePrivate(e.RequireAuth(UAAdmin, e.HandleStatus)))
 
 	// Catchall Command
 	r.HandleFallback(e.RequirePrivate(e.RequireAuth(UANone, e.HandleFallback)))

--- a/radarr/client.go
+++ b/radarr/client.go
@@ -136,3 +136,15 @@ func (c *Client) AddMovie(m Movie, qualityProfile int, path string) (movie Movie
 	movie = *resp.Result().(*Movie)
 	return
 }
+
+func (c *Client) GetSystemStatus() (SystemStatus, error) {
+	var systemStatus SystemStatus
+
+	resp, err := c.client.R().SetResult(SystemStatus{}).Get("/system/status")
+	if err != nil {
+		return systemStatus, err
+	}
+	systemStatus = *resp.Result().(*SystemStatus)
+
+	return systemStatus, nil
+}

--- a/radarr/models.go
+++ b/radarr/models.go
@@ -51,3 +51,27 @@ type AddMovieRequest struct {
 type AddMovieOptions struct {
 	SearchForMovie bool `json:"searchForMovie"`
 }
+
+type SystemStatus struct {
+	Version           string `json:"version"`
+	BuildTime         string `json:"buildTime"`
+	IsDebug           bool   `json:"isDebug"`
+	IsProduction      bool   `json:"isProduction"`
+	IsAdmin           bool   `json:"isAdmin"`
+	IsUserInteractive bool   `json:"isUserInteractive"`
+	StartupPath       string `json:"startupPath"`
+	AppData           string `json:"appData"`
+	OsName            string `json:"osName"`
+	OsVersion         string `json:"osVersion"`
+	IsMonoRuntime     bool   `json:"isMonoRuntime"`
+	IsMono            bool   `json:"isMono"`
+	IsLinux           bool   `json:"isLinux"`
+	IsOsx             bool   `json:"isOsx"`
+	IsWindows         bool   `json:"isWindows"`
+	Branch            string `json:"branch"`
+	Authentication    string `json:"authentication"`
+	SqliteVersion     string `json:"sqliteVersion"`
+	UrlBase           string `json:"urlBase"`
+	RuntimeVersion    string `json:"runtimeVersion"`
+	RuntimeName       string `json:"runtimeName"`
+}

--- a/sonarr/client.go
+++ b/sonarr/client.go
@@ -103,7 +103,6 @@ func (c *Client) GetFolders() ([]Folder, error) {
 }
 
 func (c *Client) GetProfile(prfl string) ([]Profile, error) {
-
 	resp, err := c.client.R().SetResult([]Profile{}).Get(prfl)
 	if err != nil {
 		return nil, err
@@ -112,6 +111,18 @@ func (c *Client) GetProfile(prfl string) ([]Profile, error) {
 
 	return profile, nil
 
+}
+
+func (c *Client) GetSystemStatus() (SystemStatus, error) {
+	var systemStatus SystemStatus
+
+	resp, err := c.client.R().SetResult(SystemStatus{}).Get("/system/status")
+	if err != nil {
+		return systemStatus, err
+	}
+	systemStatus = *resp.Result().(*SystemStatus)
+
+	return systemStatus, nil
 }
 
 func (c *Client) AddTVShow(m TVShow, languageProfile int, qualityProfile int, path string) (tvShow TVShow, err error) {

--- a/sonarr/models.go
+++ b/sonarr/models.go
@@ -2,7 +2,6 @@ package sonarr
 
 import (
 	"fmt"
-	"time"
 )
 
 type TVShow struct {
@@ -65,20 +64,25 @@ type AddTVShowOptions struct {
 }
 
 type SystemStatus struct {
-	Version           string    `json:"version"`
-	BuildTime         time.Time `json:"buildTime"`
-	IsDebug           bool      `json:"isDebug"`
-	IsProduction      bool      `json:"isProduction"`
-	IsAdmin           bool      `json:"isAdmin"`
-	IsUserInteractive bool      `json:"isUserInteractive"`
-	StartupPath       string    `json:"startupPath"`
-	AppData           string    `json:"appData"`
-	OsVersion         string    `json:"osVersion"`
-	IsMono            bool      `json:"isMono"`
-	IsLinux           bool      `json:"isLinux"`
-	IsWindows         bool      `json:"isWindows"`
-	Branch            string    `json:"branch"`
-	Authentication    bool      `json:"authentication"`
-	StartOfWeek       int       `json:"startOfWeek"`
-	UrlBase           string    `json:"urlBase"`
+	Version           string `json:"version"`
+	BuildTime         string `json:"buildTime"`
+	IsDebug           bool   `json:"isDebug"`
+	IsProduction      bool   `json:"isProduction"`
+	IsAdmin           bool   `json:"isAdmin"`
+	IsUserInteractive bool   `json:"isUserInteractive"`
+	StartupPath       string `json:"startupPath"`
+	AppData           string `json:"appData"`
+	OsName            string `json:"osName"`
+	OsVersion         string `json:"osVersion"`
+	IsMonoRuntime     bool   `json:"isMonoRuntime"`
+	IsMono            bool   `json:"isMono"`
+	IsLinux           bool   `json:"isLinux"`
+	IsOsx             bool   `json:"isOsx"`
+	IsWindows         bool   `json:"isWindows"`
+	Branch            string `json:"branch"`
+	Authentication    string `json:"authentication"`
+	SqliteVersion     string `json:"sqliteVersion"`
+	UrlBase           string `json:"urlBase"`
+	RuntimeVersion    string `json:"runtimeVersion"`
+	RuntimeName       string `json:"runtimeName"`
 }

--- a/sonarr/models.go
+++ b/sonarr/models.go
@@ -1,6 +1,9 @@
 package sonarr
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type TVShow struct {
 	Title     string          `json:"title"`
@@ -59,4 +62,23 @@ type AddTVShowOptions struct {
 	SearchForMissingEpisodes   bool `json:"searchForMissingEpisodes"`
 	IgnoreEpisodesWithFiles    bool `json:"ignoreEpisodesWithFiles"`
 	IgnoreEpisodesWithoutFiles bool `json:"ignoreEpisodesWithoutFiles"`
+}
+
+type SystemStatus struct {
+	Version           string    `json:"version"`
+	BuildTime         time.Time `json:"buildTime"`
+	IsDebug           bool      `json:"isDebug"`
+	IsProduction      bool      `json:"isProduction"`
+	IsAdmin           bool      `json:"isAdmin"`
+	IsUserInteractive bool      `json:"isUserInteractive"`
+	StartupPath       string    `json:"startupPath"`
+	AppData           string    `json:"appData"`
+	OsVersion         string    `json:"osVersion"`
+	IsMono            bool      `json:"isMono"`
+	IsLinux           bool      `json:"isLinux"`
+	IsWindows         bool      `json:"isWindows"`
+	Branch            string    `json:"branch"`
+	Authentication    bool      `json:"authentication"`
+	StartOfWeek       int       `json:"startOfWeek"`
+	UrlBase           string    `json:"urlBase"`
 }


### PR DESCRIPTION
This implements a new command /status which displays the contents from both sonarr and radarr's /system/status calls in the following style:

**Sonarr Status:**
Version = 3.0.3.688
BuildTime = 2020-01-12T21:37:16Z
IsDebug = false
IsProduction = true
IsAdmin = false
IsUserInteractive = false
StartupPath = /usr/lib/sonarr/bin
AppData = /config
OsName = ubuntu
OsVersion = 18.04
IsMonoRuntime = true
IsMono = true
IsLinux = true
IsOsx = false
IsWindows = false
Branch = phantom-develop
Authentication = forms
SqliteVersion = 3.22.0
UrlBase = /sonarr
RuntimeVersion = 5.20.1.34
RuntimeName = mono
RuntimeNametest =

**Radarr Status:**
Version = 3.0.0.2541
BuildTime = 2020-01-19T23:55:36Z
IsDebug = false
IsProduction = true
IsAdmin = false
IsUserInteractive = false
StartupPath = /opt/radarr
AppData = /config
OsName = ubuntu
OsVersion = 18.04
IsMonoRuntime = false
IsMono = false
IsLinux = true
IsOsx = false
IsWindows = false
Branch = develop
Authentication = forms
SqliteVersion = 3.29.0
UrlBase = /radarr
RuntimeVersion = 3.1.1
RuntimeName = netCore