### PR TITLE
fix admin msg escaping

### DIFF
--- a/util.go
+++ b/util.go
@@ -19,7 +19,7 @@ func SendError(bot *tb.Bot, to tb.Recipient, msg string) {
 
 // SendAdmin func
 func SendAdmin(bot *tb.Bot, to []User, msg string) {
-	SendMany(bot, to, fmt.Sprintf("*\\[Admin\\]* %s", msg))
+	SendMany(bot, to, fmt.Sprintf("*[Admin]* %s", msg))
 }
 
 // SendKeyboardList func


### PR DESCRIPTION
This fixes the wrong escaping in admin messages

Before:
**\\[Admin\\]** User Name has been granted admin access.

Now:
**[Admin]** User Name has been granted admin access.
